### PR TITLE
Basic project layout and ci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = true
+
+[Makefile]
+trim_trailing_whitespace = false
+indent_style = tab
+
+[.terraform-version]
+insert_final_newline = false
+trim_trailing_whitespace = true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @mongo-hydra will be requested for
+# review when someone opens a pull request.
+
+*       @mongo-hydra

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -1,0 +1,26 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run build --if-present
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # mongo-hydra
+
 A open source mongo orchestration tool with high hopes

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("Hail Hydra")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "mongo-hydra",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "mongo-hydra",
+  "version": "0.0.1",
+  "description": "A open source mongo orchestration tool with high hopes",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"no tests yet\"",
+    "lint": "echo \"no linter yet\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unumotors/mongo-hydra.git"
+  },
+  "bin": {
+    "mongo-hydra": "./cli.js"
+  },
+  "keywords": [
+    "mongo",
+    "mongodb",
+    "database",
+    "client",
+    "nodejs",
+    "operator",
+    "k8s"
+  ],
+  "author": "unu GmbH",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/unumotors/mongo-hydra/issues"
+  },
+  "homepage": "https://github.com/unumotors/mongo-hydra#readme"
+}


### PR DESCRIPTION
Adds basic project and setup.

* CI template although doesn't have any dependencies or Mongo setup yet
* npm package setup 
* cli.js (which can be moved around) and simply prints `Hello Hydra`
* Code owners linked to the GitHub group @unumotors/mongo-hydra 
* Adds a `.editorconfig`