### PR TITLE
Add logger wrapper

### DIFF
--- a/lib/helpers/logger.js
+++ b/lib/helpers/logger.js
@@ -1,0 +1,22 @@
+function info(...args) {
+  console.log(...args)
+}
+
+function debug(...args) {
+  console.log(...args)
+}
+
+function warn(...args) {
+  console.log(...args)
+}
+
+function error(...args) {
+  console.log(...args)
+}
+
+module.exports = {
+  info,
+  debug,
+  warn,
+  error
+}

--- a/test/core/diagnostic-commands.test.js
+++ b/test/core/diagnostic-commands.test.js
@@ -1,7 +1,7 @@
 const test = require('ava')
-const MongoClientStub = require('../lib/core/clients/stub-client')
-const DiagnosticCommands = require('../lib/core/commands/basic-commands')
-const MongoClient = require('../lib/core/clients/mongodb-client')
+const MongoClientStub = require('../../lib/core/clients/stub-client')
+const DiagnosticCommands = require('../../lib/core/commands/basic-commands')
+const MongoClient = require('../../lib/core/clients/mongodb-client')
 
 const MONGO_TEST_URI = process.env.MONGO_TEST_URI || 'mongodb://localhost:27017'
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,32 @@
+const test = require('ava')
+const logger = require('../lib/helpers/logger')
+
+test.serial('logger.info passes logs directly to console.log', (t) => {
+  console.log = (...args) => {
+    t.is(args[0], 'test1')
+    t.is(args[1], 'test2')
+    t.is(args[2], 'test3')
+  }
+  logger.info('test1', 'test2', 'test3')
+})
+
+test.serial('logger.debug passes logs directly to console.log', (t) => {
+  console.log = (...args) => {
+    t.is(args[0], 'debug')
+  }
+  logger.debug('debug')
+})
+
+test.serial('logger.warn passes logs directly to console.log', (t) => {
+  console.log = (...args) => {
+    t.is(args[0], 'warn')
+  }
+  logger.warn('warn')
+})
+
+test.serial('logger.error passes logs directly to console.log', (t) => {
+  console.log = (...args) => {
+    t.is(args[0], 'error')
+  }
+  logger.error('error')
+})


### PR DESCRIPTION
closes #5 

Adds simple logger wrapper for the default log levels that I plan on using: `debug`, `info`, `warn` and `error` 