### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  unit-test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -30,3 +30,21 @@ jobs:
     - run: npm run lint
     - run: npm run build --if-present
     - run: npm test
+
+  integration-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Start docker-compose
+      run: docker-compose -f test-integration/docker-compose.4.0.yaml up -d
+    - run: npm ci
+    - run: npm run test-integration

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test-dev": "nyc ava ./test/*.test.js ./test/**/*.test.js ./test/**/**/*.test.js --timeout=30s --verbose --serial",
     "test": "nyc ava ./test/*.test.js ./test/**/*.test.js ./test/**/**/*.test.js --timeout=30s --serial",
+    "test-integration": "ava ./test-integration/*.test.js --timeout=30s --serial",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },

--- a/test-integration/.eslintrc
+++ b/test-integration/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+      "no-await-in-loop": "off"
+  }
+}

--- a/test-integration/docker-compose.4.0.yaml
+++ b/test-integration/docker-compose.4.0.yaml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  replication-test-0:
+    image: mongo:4.0
+    command:
+    - '--replSet'
+    - 'replication-test'
+    - '--port'
+    - '27000'
+    ports:
+    - "27000:27000"
+  replication-test-1:
+    image: mongo:4.0
+    command:
+    - '--replSet'
+    - 'replication-test'
+    - '--port'
+    - '27001'
+    ports:
+    - "27001:27001"
+  replication-test-2:
+    image: mongo:4.0
+    command:
+    - '--replSet'
+    - 'replication-test'
+    - '--port'
+    - '27002'
+    ports:
+    - "27002:27002"

--- a/test-integration/replication.test.js
+++ b/test-integration/replication.test.js
@@ -1,0 +1,31 @@
+/**
+ * This test file tests mongo replication without sharding and auth
+ *
+ * It claims the following mongod instances:
+ * - replication-test-0
+ * - replication-test-1
+ * - replication-test-2
+ *
+ * They cannot be used in other tests
+ *
+ */
+const test = require('ava')
+const ReplicationCommands = require('../lib/core/commands/replication-commands')
+const MongoClient = require('../lib/core/clients/mongodb-client')
+
+const MONGO_TEST_REPLICATION_URIS = process.env.MONGO_TEST_REPLICATION_URIS
+ || 'mongodb://localhost:27000,mongodb://localhost:27001,mongodb://localhost:27002'
+const replicaURIs = MONGO_TEST_REPLICATION_URIS.split(',')
+
+test.serial('All instances return uninitialized status error', async (t) => {
+  t.plan(3)
+  for (let index = 0; index < replicaURIs.length; index += 1) {
+    const replicaURI = replicaURIs[index]
+    const client = new MongoClient(replicaURI)
+    await client.connect()
+    const replicationCommands = new ReplicationCommands(client)
+    await t.throwsAsync(async () => {
+      await replicationCommands.status()
+    }, { code: 94 })
+  }
+})


### PR DESCRIPTION
This MR adds the ability to run basic integration tests.

These integration tests are supposed to spin up replica set using docker-compose and just confirm that the integration tests can reach them