### PR TITLE
Add mongo versions

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+        mongo-version: [3.6, 4.0, 4.2]
 
     steps:
     - uses: actions/checkout@v2
@@ -45,6 +46,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Start docker-compose
-      run: docker-compose -f test-integration/docker-compose.4.0.yaml up -d
+      run: docker-compose -f test-integration/docker-compose.yaml up -d
+      env:
+        MONGO_VERSION: ${{ matrix.mongo-version }}
     - run: npm ci
     - run: npm run test-integration
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Similar tools like [KubeDB](https://kubedb.com/docs/0.9.0/concepts/databases/mon
 
 Right now this project is pre alpha and **not recommended for production systems.**
 
+## Tests
+
+This project is supported by unit and integration level tests.
+
+To run the unit-tests you need to provide a mongod instance without auth at localhost and run `npm run test-dev`.
+
+To run integration tests you need to run `MONGO_VERSION=4.0 docker-compose -f test-integration/docker-compose.yaml up` and `npm run test-integration`.
+
 ## Community & Contributions
 
 Although we will gladly welcome contributions in the near future we would like to first get our first minimal release as we need to aim to maintain feature parity with our internal tool, before opening it up to external contributions.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A open source mongo orchestration tool with high hopes",
   "main": "index.js",
   "scripts": {
-    "test-dev": "nyc ava ./test/*.test.js ./test/**/*.test.js ./test/**/**/*.test.js --timeout=30s --verbose --serial",
-    "test": "nyc ava ./test/*.test.js ./test/**/*.test.js ./test/**/**/*.test.js --timeout=30s --serial",
+    "test": "nyc ava ./test/*.test.js ./test/**/*.test.js ./test/**/**/*.test.js --timeout=30s --verbose --serial",
     "test-integration": "ava ./test-integration/*.test.js --timeout=30s --serial",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."

--- a/test-integration/diagnostic-commands.test.js
+++ b/test-integration/diagnostic-commands.test.js
@@ -1,0 +1,15 @@
+const test = require('ava')
+const DiagnosticCommands = require('../lib/core/commands/basic-commands')
+const MongoClient = require('../lib/core/clients/mongodb-client')
+
+const MONGO_TEST_URI = process.env.MONGO_TEST_URI || 'mongodb://localhost:27017'
+
+test('diagnostic command "ping" works as expected', async (t) => {
+  const client = new MongoClient(MONGO_TEST_URI)
+  await client.connect()
+  const basicCommands = new DiagnosticCommands(client)
+
+  const response = await basicCommands.ping()
+
+  t.deepEqual(response.ok, 1)
+})

--- a/test-integration/docker-compose.yaml
+++ b/test-integration/docker-compose.yaml
@@ -1,7 +1,18 @@
 version: '3.8'
 services:
+  ### mongod instances for diagnostic-commands.test.js
+  diagnostic-commands:
+    image: "mongo:${MONGO_VERSION}"
+    command:
+    - '--replSet'
+    - 'replication-test'
+    - '--port'
+    - '27017'
+    ports:
+    - "27017:27017"
+  ### mongod instances for replication.test.js
   replication-test-0:
-    image: mongo:4.0
+    image: "mongo:${MONGO_VERSION}"
     command:
     - '--replSet'
     - 'replication-test'
@@ -10,7 +21,7 @@ services:
     ports:
     - "27000:27000"
   replication-test-1:
-    image: mongo:4.0
+    image: "mongo:${MONGO_VERSION}"
     command:
     - '--replSet'
     - 'replication-test'
@@ -19,7 +30,7 @@ services:
     ports:
     - "27001:27001"
   replication-test-2:
-    image: mongo:4.0
+    image: "mongo:${MONGO_VERSION}"
     command:
     - '--replSet'
     - 'replication-test'

--- a/test/core/commands/diagnostic-commands.test.js
+++ b/test/core/commands/diagnostic-commands.test.js
@@ -1,11 +1,8 @@
 const test = require('ava')
 const MongoClientStub = require('../../../lib/core/clients/stub-client')
 const DiagnosticCommands = require('../../../lib/core/commands/basic-commands')
-const MongoClient = require('../../../lib/core/clients/mongodb-client')
 
-const MONGO_TEST_URI = process.env.MONGO_TEST_URI || 'mongodb://localhost:27017'
-
-test('stub: diagnostic command "ping" works as expected', async (t) => {
+test('diagnostic command "ping" works as expected', async (t) => {
   const replies = [
     { ok: 1 }
   ]
@@ -17,15 +14,5 @@ test('stub: diagnostic command "ping" works as expected', async (t) => {
 
   const sentCommand = client.getLastCommand()
   t.deepEqual(sentCommand, { ping: 1 })
-  t.deepEqual(response, { ok: 1 })
-})
-
-test('real: diagnostic command "ping" works as expected', async (t) => {
-  const client = new MongoClient(MONGO_TEST_URI)
-  await client.connect()
-  const basicCommands = new DiagnosticCommands(client)
-
-  const response = await basicCommands.ping()
-
   t.deepEqual(response, { ok: 1 })
 })

--- a/test/core/commands/replication-commands.test.js
+++ b/test/core/commands/replication-commands.test.js
@@ -2,7 +2,7 @@ const test = require('ava')
 const MongoClientStub = require('../../../lib/core/clients/stub-client')
 const ReplicationCommands = require('../../../lib/core/commands/replication-commands')
 
-test('stub: replication command "status" works as expected', async (t) => {
+test('replication command "status" works as expected', async (t) => {
   const replies = [
     { ok: 1 }
   ]
@@ -17,7 +17,7 @@ test('stub: replication command "status" works as expected', async (t) => {
   t.deepEqual(response, replies[0])
 })
 
-test('stub: replication command "getConfig" works as expected', async (t) => {
+test('replication command "getConfig" works as expected', async (t) => {
   const replies = [
     { config: { test: 1 } }
   ]
@@ -32,7 +32,7 @@ test('stub: replication command "getConfig" works as expected', async (t) => {
   t.deepEqual(response, { test: 1 })
 })
 
-test('stub: replication command "initiate" works as expected', async (t) => {
+test('replication command "initiate" works as expected', async (t) => {
   const replies = [
     { ok: 1 }
   ]
@@ -48,7 +48,7 @@ test('stub: replication command "initiate" works as expected', async (t) => {
   t.deepEqual(response, replies[0])
 })
 
-test('stub: replication command "reconfig" works as expected', async (t) => {
+test('replication command "reconfig" works as expected', async (t) => {
   const replies = [
     { ok: 1 }
   ]


### PR DESCRIPTION
This adds more mongo versions to the matrix.

GitHub Actions provide 20 concurrent jobs for free. 

Let's add this and see if we may ditch a version down the road. This at least makes that a concious desition.