### PR TITLE
Add basic docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+test
+test-integration

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -7,18 +7,20 @@ on:
     branches: [ master ]
 
 jobs:
+  docker-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build docker image
+      run: docker build .
+
   unit-test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-
-    services:
-      mongodb:
-        image: mongo
-        ports:
-        - 27017:27017
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:14-alpine
+
+WORKDIR /app
+
+COPY LICENSE .
+
+COPY package.json package-lock.json ./
+COPY lib ./lib
+COPY cli.js index.js ./
+RUN npm install --production
+
+USER node
+
+ENTRYPOINT [ "/app/cli.js" ]


### PR DESCRIPTION
Adds a basic docker file, this will be used to generate `unumotors/mongo-hydra` automatically using their integration. 


Need to test the CI part of building the action

Closes #4 