### PR TITLE
Run tests against 4.4-rc

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        mongo-version: [3.6, 4.0, 4.2]
+        mongo-version: [3.6, 4.0, 4.2, 4.4-rc]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Similar tools like [KubeDB](https://kubedb.com/docs/0.9.0/concepts/databases/mon
 |                 | Sharded cluster       | ⛔        | ⛔           | ⛔         |
 |                 | User management       | ⛔        | ⛔           | ⛔         |
 |                 | Admin user setup      | ⛔        | ✅ (k8s)     | ✅(k8s)    |
-|                 | Mongo version support | ✅ =<4.2  | 🟠 3.6       | ✅ 4.2     |
+|                 | Mongo version support | ✅ =<4.4| 🟠 3.6       | ✅ 4.2     |
 | Security        | Certificates          | ⛔        | ⛔           | ✅         |
 |                 | Keyfiles              | ⛔        | ✅           | ⛔         |
 |                 | Encryption at rest    | ⛔        | ⛔           | ✅         |


### PR DESCRIPTION
Although not fully supported yet let's make sure we run our tests against Mongo 4.4-rc so  we  are fully ready for its release.

Also, it's a nice readme update.