### PR TITLE
Optimise npm package size by only including required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "mongo-hydra": "./cli.js",
     "hydra": "./cli.js"
   },
+  "files": [
+    "/lib",
+    "cli.js",
+    "index.js"
+  ],
   "keywords": [
     "mongo",
     "mongodb",


### PR DESCRIPTION
Goes from `39.9 kB` to `6.5 kB`

```
npm notice
npm notice 📦  mongo-hydra@0.0.2
npm notice === Tarball Contents ===
npm notice 1.2kB package.json
npm notice 35B   .dockerignore
npm notice 560B  .editorconfig
npm notice 360B  .eslintrc.js
npm notice 341B  cli.js
npm notice 365B  CONTRIBUTING.md
npm notice 199B  Dockerfile
npm notice 0     index.js
npm notice 1.1kB LICENSE
npm notice 4.9kB README.md
npm notice 214B  .github/CODEOWNERS
npm notice 1.2kB .github/workflows/pullrequest.yaml
npm notice 229B  lib/cli/replication.js
npm notice 700B  lib/core/clients/mongodb-client.js
npm notice 807B  lib/core/clients/stub-client.js
npm notice 219B  lib/core/commands/basic-commands.js
npm notice 770B  lib/core/commands/replication-commands.js
npm notice 473B  lib/core/helpers/enums.js
npm notice 0     lib/core/index.js
npm notice 1.4kB lib/core/state/mongo-server-replica-member.js
npm notice 637B  lib/core/state/mongo-server.js
npm notice 3.7kB lib/core/state/replication.js
npm notice 260B  lib/helpers/logger.js
npm notice 528B  test-integration/diagnostic-commands.test.js
npm notice 824B  test-integration/docker-compose.yaml
npm notice 1.5kB test-integration/replication.test.js
npm notice 1.0kB test/cli/replication.test.js
npm notice 1.0kB test/core/clients/client-stub.test.js
npm notice 2.0kB test/core/clients/mongo-client.test.js
npm notice 601B  test/core/commands/diagnostic-commands.test.js
npm notice 2.2kB test/core/commands/replication-commands.test.js
npm notice 3.9kB test/core/state/mongo-server-replica-member.test.js
npm notice 688B  test/core/state/mongo-server.test.js
npm notice 5.2kB test/core/state/replication.test.js
npm notice 794B  test/logger.test.js
npm notice === Tarball Details ===
npm notice name:          mongo-hydra
npm notice version:       0.0.2
npm notice package size:  10.3 kB
npm notice unpacked size: 39.9 kB
npm notice shasum:        e756a0f2cd2c009a4bf4932783ab85450ab6769a
npm notice integrity:     sha512-j2QTGs2XLm3aB[...]pAYTUXxHGnGXQ==
npm notice total files:   35
npm notice
+ mongo-hydra@0.0.2
```

To 

```
npm pack
npm notice
npm notice 📦  mongo-hydra@0.2.0
Optimise npm package size by only including required files
npm notice === Tarball Contents ===
npm notice 1.4kB package.json
npm notice 765B  cli.js
npm notice 0     index.js
npm notice 1.1kB LICENSE
npm notice 5.8kB README.md
npm notice 761B  lib/cli/replication.js
npm notice 700B  lib/core/clients/mongodb-client.js
npm notice 807B  lib/core/clients/stub-client.js
npm notice 219B  lib/core/commands/basic-commands.js
npm notice 770B  lib/core/commands/replication-commands.js
npm notice 473B  lib/core/helpers/enums.js
npm notice 0     lib/core/index.js
npm notice 1.4kB lib/core/state/mongo-server-replica-member.js
npm notice 637B  lib/core/state/mongo-server.js
npm notice 3.7kB lib/core/state/replication.js
npm notice 260B  lib/helpers/logger.js
npm notice === Tarball Details ===
npm notice name:          mongo-hydra
npm notice version:       0.2.0
npm notice filename:      mongo-hydra-0.2.0.tgz
npm notice package size:  6.5 kB
npm notice unpacked size: 18.7 kB
npm notice shasum:        2e795dd865d6f6a10642f0ba5f5ddf0f39bfb714
npm notice integrity:     sha512-eFu1rixgRxJzb[...]wZ7acvjTjX04A==
npm notice total files:   16
npm notice
mongo-hydra-0.2.0.tgz
```

Closes #38 